### PR TITLE
Added color via ANSI escape codes

### DIFF
--- a/wantyougone.py
+++ b/wantyougone.py
@@ -74,14 +74,20 @@ if os.path.exists(bg_music_file):
 original_wpm = 800 
 wpm = original_wpm
 
+print("\033[38;2;255;212;87m") # set foreground color
+print("\033[48;2;78;44;11m") # set background color
+print("\033[2J") # clear screen
+print("\033[H") # set cursor to top left position
+
 for line in lyrics.split("\n"):
     if '/c' in line:
-        os.system('cls' if os.name == 'nt' else 'clear')
+        print("\033[2J") # clear screen
+        print("\033[H") # set cursor to top left position
     elif line.strip() and '/nl' not in line:
         type_with_wpm(line, wpm)
         print()
     elif line.strip():
         type_with_wpm(line, wpm)
 
-
+print("\033[0;0m") # reset all formatting
 pygame.mixer.music.stop()


### PR DESCRIPTION
This PR adds the fitting foreground and background colors via [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code). I also replaced the OS dependent clear function with the ANSI equivalent while I was at it. This currently breaks the GUI mode, but as the GUI mode only seems to circumvent the color issue I wonder if its worth to keep it up anyway. I can fix that if necessary tho. 